### PR TITLE
Ship a cross-desktop ignoreApps default

### DIFF
--- a/src/openvfsfuse/config.json
+++ b/src/openvfsfuse/config.json
@@ -1,11 +1,37 @@
 {
     "ignoreApps": {
         "byName": [
-            "/usr/bin/dolphin"
         ],
         "endsWith": [
+            "dolphin",
             "kioworker",
-            "baloo_file"
+            "baloo_file",
+            "baloo_file_extractor",
+            "nautilus",
+            "nemo",
+            "caja",
+            "thunar",
+            "pcmanfm",
+            "pcmanfm-qt",
+            "thumbnailer",
+            "gnome-thumbnail-font",
+            "gnome-thumbnail-factory",
+            "tumblerd",
+            "tracker-miner-fs",
+            "tracker-miner-fs-3",
+            "tracker-extract",
+            "tracker-extract-3",
+            "localsearch-3",
+            "localsearch-extractor-3",
+            "gvfsd",
+            "gvfsd-metadata",
+            "gvfsd-trash",
+            "updatedb",
+            "updatedb.mlocate",
+            "updatedb.plocate",
+            "clamd",
+            "clamscan",
+            "freshclam"
         ]
     }
 }


### PR DESCRIPTION
Split out of #54.

The shipped `ignoreApps` list was KDE-only, so on GNOME/Cinnamon/MATE/Xfce nothing was blocked: browsing a folder downloaded everything in it, indexing downloaded the sync root.

Now covers the common file managers, the freedesktop thumbnailer convention, tracker/localsearch, gvfs helpers, `updatedb` and ClamAV. `/usr/bin/dolphin` moved from `byName` to an `endsWith` entry so it holds across distributions.

Two things I left alone on purpose:

- This stays a deny-list. Enumerating every indexer, thumbnailer and antivirus doesn't converge — a permit-list of what *should* trigger a download is a smaller, more stable set, but that's your design call.
- A blocked caller still gets `EPERM`. Whether `ENODATA` or serving placeholder content behaves better across thumbnailers has real tradeoffs.

The GNOME entries are checked against a live install (all four `/usr/share/thumbnailers` entries covered, including `gnome-thumbnail-font`, which doesn't match the `-thumbnailer` convention). KDE, Xfce, Cinnamon and MATE are from documentation and unverified — worth a second pair of eyes from someone running those.

Related: #59, #52.
