### PR TITLE
Make SPDX headers consistent and complete

### DIFF
--- a/src/openvfs/openvfs.cpp
+++ b/src/openvfs/openvfs.cpp
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2025 Hannah von Reth <h.vonreth@opencloud.eu>
 
 #include "openvfs/openvfs.h"

--- a/src/openvfsfuse/main.cpp
+++ b/src/openvfsfuse/main.cpp
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Hannah von Reth <h.vonreth@opencloud.eu>
+// SPDX-FileCopyrightText: 2025 Klaas Freitag <k.freitag@opencloud.eu>
+
 #include "openvfsfuse.h"
 
 #include <cassert>

--- a/src/openvfsfuse/sharedmap.cpp
+++ b/src/openvfsfuse/sharedmap.cpp
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Klaas Freitag <k.freitag@opencloud.eu>
+
 /*
  * openvfsfuse - a Fuse layer to handle virtual filesystem items of cloud storage
  * Copyright (C) 2025  Klaas Freitag <k.freitag@opencloud.eu>

--- a/src/openvfsfuse/sharedmap.h
+++ b/src/openvfsfuse/sharedmap.h
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2025 Klaas Freitag <k.freitag@opencloud.eu>
+
 /*
  * openvfsfuse - a Fuse layer to handle virtual filesystem items of cloud storage
  * Copyright (C) 2025  Klaas Freitag <k.freitag@opencloud.eu>

--- a/src/openvfsfuse/strtools.h
+++ b/src/openvfsfuse/strtools.h
@@ -1,8 +1,8 @@
-#ifndef STRTOOLS_H
-#define STRTOOLS_H
-
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Klaas Freitag <k.freitag@opencloud.eu>
+
+#ifndef STRTOOLS_H
+#define STRTOOLS_H
 
 #pragma once
 #include <string>


### PR DESCRIPTION
Split out of #54.

`src/openvfs/` is one library in one directory but gave three licensing answers: four files `GPL-3.0-or-later`, `openvfs.cpp` `GPL-2.0-or-later`, and three files in `src/openvfsfuse/` with no tag at all. `libopenvfs` is what downstream clients link against, so its license determines the license of the combined binary they ship.

`openvfs.cpp` aligned with the other four and with the top-level LICENSE, missing tags added to `main.cpp` and `sharedmap.{h,cpp}` (which already carried the full GPL-3 notice in prose), and the tag in `strtools.h` moved above the include guard like everywhere else.

`socketthread.{h,cpp}` deliberately left alone — they carry third-party MIT code alongside the GPL-3 notice, and pinning one expression on that is your call, not a drive-by fix. A `REUSE.toml` would make the tree checkable with `reuse lint`; happy to do that as a follow-up if you want it.

